### PR TITLE
Feat: PSO optimizer + per-step streaming + YouTube demo (closes #5)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -29,6 +29,7 @@ from ..simulation.sampling import (
     penalized_adaptive_sampling,
     hybrid_stratified_adaptive_sampling,
     multiscale_adaptive_sampling,
+    pso_sampling,
     apply_sampling,
 )
 from ..simulation.field_generator import generate_training_ensemble
@@ -64,7 +65,8 @@ class SampleRequest(BaseModel):
         description=(
             "Sampling method: random_uniform, stratified, random_stratified, "
             "multiscale_stratified, oracle_entropy, adaptive_entropy, "
-            "penalized_adaptive, hybrid_stratified_adaptive, multiscale_adaptive"
+            "penalized_adaptive, hybrid_stratified_adaptive, multiscale_adaptive, "
+            "pso"
         ),
     )
     num_samples: int = Field(default=20, ge=1, le=1000)
@@ -214,7 +216,7 @@ async def sample_endpoint(req: SampleRequest) -> Dict[str, Any]:
             true_field, training_image, req.num_samples,
             pattern_radius=req.pattern_radius, seed=req.seed,
         )
-    elif method in ("penalized_adaptive", "hybrid_stratified_adaptive", "multiscale_adaptive"):
+    elif method in ("penalized_adaptive", "hybrid_stratified_adaptive", "multiscale_adaptive", "pso"):
         # Generate training ensemble for multi-TI methods
         ti_seed = (req.seed + 2000) if req.seed is not None else None
         training_ensemble = generate_training_ensemble(
@@ -232,6 +234,11 @@ async def sample_endpoint(req: SampleRequest) -> Dict[str, Any]:
             mask, order, ent_hist = hybrid_stratified_adaptive_sampling(
                 true_field, training_ensemble, req.num_samples,
                 pattern_radius=req.pattern_radius, seed=req.seed,
+            )
+        elif method == "pso":
+            mask, order, ent_hist = pso_sampling(
+                true_field, training_ensemble, req.num_samples,
+                seed=req.seed,
             )
         else:  # multiscale_adaptive
             mask, order, ent_hist = multiscale_adaptive_sampling(
@@ -420,7 +427,7 @@ async def process_animated(req: AnimatedRequest) -> Dict[str, Any]:
             true_field, training_image, req.num_samples,
             pattern_radius=req.pattern_radius, seed=req.seed,
         )
-    elif method in ("penalized_adaptive", "hybrid_stratified_adaptive", "multiscale_adaptive"):
+    elif method in ("penalized_adaptive", "hybrid_stratified_adaptive", "multiscale_adaptive", "pso"):
         ti_seed = (req.seed + 2000) if req.seed is not None else None
         training_ensemble = generate_training_ensemble(
             field_type=_state["field_type"] or "multi_channel",
@@ -437,6 +444,11 @@ async def process_animated(req: AnimatedRequest) -> Dict[str, Any]:
             mask, order, _ = hybrid_stratified_adaptive_sampling(
                 true_field, training_ensemble, req.num_samples,
                 pattern_radius=req.pattern_radius, seed=req.seed,
+            )
+        elif method == "pso":
+            mask, order, _ = pso_sampling(
+                true_field, training_ensemble, req.num_samples,
+                seed=req.seed,
             )
         else:
             mask, order, _ = multiscale_adaptive_sampling(
@@ -538,7 +550,7 @@ async def process_step(req: StepRequest) -> Dict[str, Any]:
                 true_field, training_image, req.num_samples,
                 pattern_radius=req.pattern_radius, seed=req.seed,
             )
-        elif method in ("penalized_adaptive", "hybrid_stratified_adaptive", "multiscale_adaptive"):
+        elif method in ("penalized_adaptive", "hybrid_stratified_adaptive", "multiscale_adaptive", "pso"):
             ti_seed = (req.seed + 2000) if req.seed is not None else None
             training_ensemble = generate_training_ensemble(
                 field_type=_state["field_type"] or "multi_channel",
@@ -554,6 +566,11 @@ async def process_step(req: StepRequest) -> Dict[str, Any]:
                 mask, order, _ = hybrid_stratified_adaptive_sampling(
                     true_field, training_ensemble, req.num_samples,
                     pattern_radius=req.pattern_radius, seed=req.seed,
+                )
+            elif method == "pso":
+                mask, order, _ = pso_sampling(
+                    true_field, training_ensemble, req.num_samples,
+                    seed=req.seed,
                 )
             else:
                 mask, order, _ = multiscale_adaptive_sampling(

--- a/app/simulation/sampling.py
+++ b/app/simulation/sampling.py
@@ -967,6 +967,124 @@ def multiscale_adaptive_sampling(
     return sampled_mask, sample_order, entropy_history
 
 
+def pso_sampling(
+    field: np.ndarray,
+    training_images: list,
+    num_samples: int,
+    n_particles: int = 20,
+    n_iterations: int = 50,
+    seed: Optional[int] = None,
+) -> Tuple[np.ndarray, np.ndarray, List[float]]:
+    """Particle Swarm Optimization for well placement.
+
+    Each particle represents a set of K sample positions.
+    The fitness function is the total information gain:
+        fitness = H(X) - H(X | sampled positions)
+
+    PSO update rules:
+        v_i = w*v_i + c1*r1*(pbest_i - x_i) + c2*r2*(gbest - x_i)
+        x_i = x_i + v_i
+
+    Positions are continuous in [0, H) x [0, W) and rounded to
+    integer grid positions for evaluation.
+
+    Args:
+        field: 2D binary field (H, W).
+        training_images: List of training images.
+        num_samples: K samples to place.
+        n_particles: Number of PSO particles.
+        n_iterations: Maximum iterations.
+        seed: Random seed.
+
+    Returns:
+        Tuple of (sampled_mask, sample_order, fitness_history):
+        - sampled_mask: Boolean array (H, W) of sampled positions.
+        - sample_order: Int array (H, W) with order of sampling (0 = unsampled).
+        - fitness_history: List of best fitness at each iteration.
+    """
+    rng = np.random.default_rng(seed)
+    H, W = field.shape
+    K = num_samples
+
+    # Initialize particles: each is K positions (shape: n_particles x K x 2)
+    particles = rng.uniform(0, [H, W], size=(n_particles, K, 2))
+    velocities = rng.uniform(-1, 1, size=(n_particles, K, 2))
+
+    # PSO parameters
+    w = 0.7    # inertia
+    c1 = 1.5   # cognitive (personal best)
+    c2 = 1.5   # social (global best)
+
+    pbest = particles.copy()
+    pbest_fitness = np.full(n_particles, -np.inf)
+    gbest = particles[0].copy()
+    gbest_fitness = -np.inf
+
+    marginal_p = np.mean([np.mean(ti) for ti in training_images])
+    total_entropy = total_field_entropy(np.full((H, W), marginal_p))
+
+    fitness_history: List[float] = []
+
+    for iteration in range(n_iterations):
+        for i in range(n_particles):
+            # Round positions to grid
+            positions = np.clip(particles[i].astype(int), [0, 0], [H - 1, W - 1])
+
+            # Remove duplicates
+            unique_positions = np.unique(positions, axis=0)
+
+            # Evaluate fitness: information gain
+            mask = np.zeros((H, W), dtype=bool)
+            for r, c in unique_positions:
+                mask[r, c] = True
+
+            prob = np.full((H, W), marginal_p)
+            prob[mask] = field[mask].astype(float)
+            ent = entropy_map(prob)
+            ent[mask] = 0.0
+            remaining = float(np.sum(ent))
+            fitness = total_entropy - remaining
+
+            # Update personal best
+            if fitness > pbest_fitness[i]:
+                pbest_fitness[i] = fitness
+                pbest[i] = particles[i].copy()
+
+            # Update global best
+            if fitness > gbest_fitness:
+                gbest_fitness = fitness
+                gbest = particles[i].copy()
+
+        fitness_history.append(float(gbest_fitness))
+
+        # PSO velocity update
+        r1 = rng.random(size=(n_particles, K, 2))
+        r2 = rng.random(size=(n_particles, K, 2))
+        velocities = (w * velocities +
+                      c1 * r1 * (pbest - particles) +
+                      c2 * r2 * (gbest[np.newaxis] - particles))
+
+        # Clamp velocity
+        velocities = np.clip(velocities, -2, 2)
+
+        # Update positions
+        particles += velocities
+        particles[:, :, 0] = np.clip(particles[:, :, 0], 0, H - 1)
+        particles[:, :, 1] = np.clip(particles[:, :, 1], 0, W - 1)
+
+    # Extract best solution
+    best_positions = np.clip(gbest.astype(int), [0, 0], [H - 1, W - 1])
+    unique_best = np.unique(best_positions, axis=0)
+
+    mask = np.zeros((H, W), dtype=bool)
+    order = np.zeros((H, W), dtype=int)
+    for k, (r, c) in enumerate(unique_best[:K]):
+        mask[r, c] = True
+        order[r, c] = k + 1
+
+    return mask, order, fitness_history
+
+
 def apply_sampling(
     true_field: np.ndarray,
     positions: np.ndarray,

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -57,6 +57,7 @@
                     <option value="penalized_adaptive">Penalized Adaptive (AdSEMES + Penalty)</option>
                     <option value="hybrid_stratified_adaptive">Hybrid Stratified + Adaptive</option>
                     <option value="multiscale_adaptive">Multiscale Adaptive</option>
+                    <option value="pso">PSO (Particle Swarm Optimization)</option>
                 </select>
             </div>
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -20,6 +20,7 @@ from app.simulation.sampling import (
     penalized_adaptive_sampling,
     hybrid_stratified_adaptive_sampling,
     multiscale_adaptive_sampling,
+    pso_sampling,
     apply_sampling,
 )
 from app.simulation.field_generator import (
@@ -236,6 +237,43 @@ def test_multi_ti_probability():
     print("  [PASS] multi_ti_probability")
 
 
+def test_pso_sampling():
+    """PSO sampling produces valid positions with positive fitness."""
+    field = generate_random_field(FIELD_SHAPE, proportion=0.3, correlation_length=5, seed=42)
+    training_images = generate_training_ensemble(
+        field_type='random', n_realizations=3,
+        field_size=(48, 48), seed=400,
+    )
+
+    mask, order, fitness_hist = pso_sampling(
+        field, training_images, num_samples=10,
+        n_particles=10, n_iterations=15, seed=42,
+    )
+
+    # Check samples were placed
+    num_placed = int(np.sum(mask))
+    assert num_placed > 0, "PSO should place at least 1 sample"
+    assert num_placed <= 10, f"Too many samples: {num_placed}"
+
+    # Check all positions in bounds
+    positions = np.argwhere(mask)
+    assert np.all(positions[:, 0] >= 0) and np.all(positions[:, 0] < FIELD_SHAPE[0])
+    assert np.all(positions[:, 1] >= 0) and np.all(positions[:, 1] < FIELD_SHAPE[1])
+
+    # Fitness should be non-negative and non-decreasing (global best)
+    assert len(fitness_hist) == 15, f"Expected 15 fitness values, got {len(fitness_hist)}"
+    assert all(f >= 0 for f in fitness_hist), "Fitness should be non-negative"
+    # Global best fitness should be monotonically non-decreasing
+    for i in range(1, len(fitness_hist)):
+        assert fitness_hist[i] >= fitness_hist[i - 1] - 1e-10, \
+            f"Global best fitness decreased at iteration {i}"
+
+    # Order values should be sequential from 1
+    orders = sorted(order[mask])
+    assert orders[0] == 1, f"First order should be 1, got {orders[0]}"
+    print("  [PASS] pso_sampling")
+
+
 def test_training_ensemble_generation():
     """Training ensemble generates the right number of distinct TIs."""
     ensemble = generate_training_ensemble(
@@ -265,5 +303,6 @@ if __name__ == '__main__':
     test_hybrid_stratified_adaptive()
     test_multiscale_adaptive()
     test_multi_ti_probability()
+    test_pso_sampling()
     test_training_ensemble_generation()
     print("\nAll sampling tests passed!")


### PR DESCRIPTION
## Summary
- PSO (Particle Swarm Optimization) sampling with w=0.7, c1=1.5, c2=1.5
- Per-step streaming endpoint POST /api/process-step (non-blocking)
- Compare page redesigned with vertical rows + speed control
- Navigation link between main page ↔ compare page
- YouTube demo video in README
- Closes #5

## Test plan
- [ ] `python tests/test_entropy.py && python tests/test_sampling.py && python tests/test_integration.py`
- [ ] Open http://localhost:8008/compare — verify step-by-step animation

@codex PSO с w=0.7 сходится, но медленнее чем жадный AdSEMES для малых K. Как бы ты гибридизировал — жадный для первых K/2 сэмплов, потом PSO для остальных? 🇷🇺

**CODE REVIEW ONLY.**
🤖 Generated with [Claude Code](https://claude.ai/claude-code)